### PR TITLE
Modern Swift concurrency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,11 @@
 
 import PackageDescription
 
+let approachableConcurrency: [SwiftSetting] = [
+  .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
+  .enableUpcomingFeature("InferIsolatedConformances")
+]
+
 let package = Package(
   name: "Hearts",
   defaultLocalization: "en",
@@ -31,7 +36,8 @@ let package = Package(
     // Targets can depend on other targets in this package, and on products in packages this package depends on.
     .target(
       name: "libCommon",
-      resources: [.process("Localizable.xcstrings")]
+      resources: [.process("Localizable.xcstrings")],
+      swiftSettings: approachableConcurrency
     ),
     .target(
       name: "libHearts",
@@ -40,7 +46,8 @@ let package = Package(
         .copy("Resources/colors.json"),
         .copy("Resources/groups.json"),
         .process("Localizable.xcstrings")
-      ]
+      ],
+      swiftSettings: approachableConcurrency
     ),
     .executableTarget(
       name: "Hearts",
@@ -48,12 +55,14 @@ let package = Package(
         "libHearts",
         .product(name: "ArgumentParser", package: "swift-argument-parser")
       ],
-      resources: [.process("Localizable.xcstrings")]
+      resources: [.process("Localizable.xcstrings")],
+      swiftSettings: approachableConcurrency
     ),
     .testTarget(
       name: "HeartsTests",
       dependencies: ["libHearts", "Nimble", "Quick"],
-      resources: [.process("Resources")]
+      resources: [.process("Resources")],
+      swiftSettings: approachableConcurrency
     ),
     .executableTarget(
       name: "GenerateColors",
@@ -62,19 +71,22 @@ let package = Package(
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
         .product(name: "Progress", package: "Progress.swift")
       ],
-      resources: [.process("Resources")]
+      resources: [.process("Resources")],
+      swiftSettings: approachableConcurrency
     ),
     .executableTarget(
       name: "GenerateGroups",
       dependencies: [
         .product(name: "ArgumentParser", package: "swift-argument-parser")
-      ]
+      ],
+      swiftSettings: approachableConcurrency
     ),
     .executableTarget(
       name: "GenerateCharacters",
       dependencies: [
         .product(name: "ArgumentParser", package: "swift-argument-parser")
-      ]
+      ],
+      swiftSettings: approachableConcurrency
     )
   ],
   swiftLanguageModes: [.v6]

--- a/Sources/GenerateColors/GenerateColors.swift
+++ b/Sources/GenerateColors/GenerateColors.swift
@@ -44,53 +44,48 @@ struct GenerateColors: AsyncParsableCommand {
     try data.write(to: output)
   }
 
-  private func characterToImage(_ character: Character, extent: Int = 216) async throws -> CGImage {
-    return try await withCheckedThrowingContinuation { continuation in
-      guard let colorspace = CGColorSpace(name: CGColorSpace.sRGB) else {
-        continuation.resume(with: .failure(Error.drawingError))
-        return
-      }
-      guard
-        let context = CGContext(
-          data: nil,
-          width: extent,
-          height: extent,
-          bitsPerComponent: 8,
-          bytesPerRow: 0,
-          space: colorspace,
-          bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
-        )
-      else {
-        continuation.resume(with: .failure(Error.drawingError))
-        return
-      }
-
-      let path = CGPath(rect: CGRect(x: 0, y: 0, width: extent, height: extent), transform: nil)
-      let font = CTFont(.system, size: CGFloat(Double(extent) * 0.75))
-      let attributes = [
-        kCTFontAttributeName: font
-      ]
-      let cfString = String(character) as CFString
-      let attrString = CFAttributedStringCreate(nil, cfString, attributes as CFDictionary)!
-
-      let framesetter = CTFramesetterCreateWithAttributedString(attrString)
-      let frame = CTFramesetterCreateFrame(
-        framesetter,
-        CFRange(location: 0, length: CFStringGetLength(cfString)),
-        path,
-        nil
-      )
-      CTFrameDraw(frame, context)
-
-      context.flush()
-
-      guard let image = context.makeImage() else {
-        continuation.resume(with: .failure(Error.drawingError))
-        return
-      }
-
-      continuation.resume(with: .success(image))
+  private func characterToImage(_ character: Character, extent: Int = 216) throws -> CGImage {
+    guard let colorspace = CGColorSpace(name: CGColorSpace.sRGB) else {
+      throw Error.drawingError
     }
+    guard
+      let context = CGContext(
+        data: nil,
+        width: extent,
+        height: extent,
+        bitsPerComponent: 8,
+        bytesPerRow: 0,
+        space: colorspace,
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+      )
+    else {
+      throw Error.drawingError
+    }
+
+    let path = CGPath(rect: CGRect(x: 0, y: 0, width: extent, height: extent), transform: nil)
+    let font = CTFont(.system, size: CGFloat(Double(extent) * 0.75))
+    let attributes = [
+      kCTFontAttributeName: font
+    ]
+    let cfString = String(character) as CFString
+    let attrString = CFAttributedStringCreate(nil, cfString, attributes as CFDictionary)!
+
+    let framesetter = CTFramesetterCreateWithAttributedString(attrString)
+    let frame = CTFramesetterCreateFrame(
+      framesetter,
+      CFRange(location: 0, length: CFStringGetLength(cfString)),
+      path,
+      nil
+    )
+    CTFrameDraw(frame, context)
+
+    context.flush()
+
+    guard let image = context.makeImage() else {
+      throw Error.drawingError
+    }
+
+    return image
   }
 
   private func characterImages() async throws -> [(Character, CGImage)] {
@@ -100,7 +95,7 @@ struct GenerateColors: AsyncParsableCommand {
 
       for character in try characters {
         group.addTask {
-          let image = try await characterToImage(character)
+          let image = try characterToImage(character)
           await ProgressWrapper.shared.next()
           return (character, image)
         }

--- a/Sources/GenerateGroups/GenerateGroups.swift
+++ b/Sources/GenerateGroups/GenerateGroups.swift
@@ -54,10 +54,10 @@ struct GenerateGroups: AsyncParsableCommand {
 
       if line.starts(with: "# group: ") {
         let group = String(line.suffix(from: line.index(line.startIndex, offsetBy: 9)))
-        groups.currentGroup = group
+        await groups.setCurrentGroup(group)
       } else if line.starts(with: "# subgroup: ") {
         let subgroup = String(line.suffix(from: line.index(line.startIndex, offsetBy: 12)))
-        groups.currentSubgroup = subgroup
+        await groups.setCurrentSubgroup(subgroup)
       } else if line.starts(with: "#") {
         continue
       } else {
@@ -147,20 +147,15 @@ actor Group {
   }
 }
 
-class Groups {
+actor Groups {
   private var groups: [Group] = []
-  private var groupsMutex = DispatchSemaphore(value: 1)
-
-  var currentGroup: String? {
-    willSet { groupsMutex.wait() }
-    didSet { groupsMutex.signal() }
-  }
-  var currentSubgroup: String? {
-    willSet { groupsMutex.wait() }
-    didSet { groupsMutex.signal() }
-  }
+  private var currentGroup: String?
+  private var currentSubgroup: String?
 
   private let allowedNameChars = CharacterSet.alphanumerics.union(CharacterSet.newlines)
+
+  func setCurrentGroup(_ name: String) { currentGroup = name }
+  func setCurrentSubgroup(_ name: String) { currentSubgroup = name }
 
   func addChar(_ char: Character) async throws {
     guard let currentGroup,

--- a/Sources/libHearts/EmojiArt.swift
+++ b/Sources/libHearts/EmojiArt.swift
@@ -1,4 +1,4 @@
-@preconcurrency import CoreImage
+import CoreImage
 import Foundation
 import libCommon
 


### PR DESCRIPTION
## Summary

Adopts Swift's Approachable Concurrency upcoming features across all targets and migrates the package's remaining legacy-concurrency sites to modern structured concurrency.

- Enable `NonisolatedNonsendingByDefault` and `InferIsolatedConformances` upcoming features for every target in `Package.swift`.
- **GenerateGroups**: convert `class Groups` to an `actor`, deleting its `DispatchSemaphore` mutex and the `willSet`/`didSet` locking on `currentGroup`/`currentSubgroup` in favor of actor-isolated setter methods. This removes the package's only remaining GCD primitive and aligns `Groups` with its already-actor nested types.
- **GenerateColors**: drop an unnecessary `withCheckedThrowingContinuation` that wrapped synchronous Core Graphics drawing, turning `characterToImage(_:extent:)` into a plain synchronous throwing function.
- **libHearts**: remove the vestigial `@preconcurrency import CoreImage` now that its types are fully Sendable-audited.

No public API changes: the `EmojiArt` actor (with its async initializers, `process(image:)`, and `setBackgroundColor(_:)`) and the `Color` value type remain source-compatible. The migrated sites all live in internal/executable code.

## Verification

- `swift build --build-tests` succeeds.
- `swift test` passes (5/5).
- `swift format` applied to the changed files; `swiftlint` reports 0 violations.
- No E2E targets exist in this package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
